### PR TITLE
chore: 🔧 Update `prepareCmd` in `.releaserc` for manifest path change

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -18,7 +18,7 @@
         [
             "@semantic-release/exec",
             {
-              "prepareCmd": "npx node-jq '.version = \"nextRelease.version\"' custom_components/fujitsu_airstage/manifest.json"
+              "prepareCmd": "npx node-jq '.version = \"nextRelease.version\"' custom_components/diagral/manifest.json"
             }
         ],
         ["@semantic-release/git", {


### PR DESCRIPTION
* Changed the path in `prepareCmd` to point to `custom_components/diagral/manifest.json`
* Ensures correct versioning for the Diagral component