### PR TITLE
fix: 🔧 Update `.releaserc` to restructure `@semantic-release/git` con…

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -21,13 +21,16 @@
               "prepareCmd": "npx node-jq '.version = \"nextRelease.version\"' custom_components/diagral/manifest.json"
             }
         ],
-        ["@semantic-release/git", {
-            "assets": [
-                "CHANGELOG.md",
-                "custom_components/diagral/manifest.json"
-            ],
-            "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-        }],
-        "@semantic-release/github"
+        "@semantic-release/github",
+        [
+            "@semantic-release/git",
+            {
+                "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+                "assets": [
+                    "CHANGELOG.md",
+                    "custom_components/diagral/manifest.json"
+                ]
+            }
         ]
+    ]
 }


### PR DESCRIPTION
…figuration

* Moved the `@semantic-release/git` configuration to align with best practices.
* Ensured the `message` and `assets` are properly nested for clarity.