### PR TITLE
fix: 🔧 Update `prepareCmd` in `.releaserc` to use template variable

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -18,7 +18,7 @@
         [
             "@semantic-release/exec",
             {
-              "prepareCmd": "npx node-jq '.version = \"nextRelease.version\"' custom_components/diagral/manifest.json"
+              "prepareCmd": "npx node-jq '.version = \"${nextRelease.version}\"' custom_components/diagral/manifest.json"
             }
         ],
         "@semantic-release/github",


### PR DESCRIPTION
* Changed `prepareCmd` to use `${nextRelease.version}` for better clarity.