### PR TITLE
fix: 🔧 Correct `prepareCmd` in `.releaserc` to overwrite manifest.json

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -18,7 +18,7 @@
         [
             "@semantic-release/exec",
             {
-              "prepareCmd": "npx node-jq '.version = \"${nextRelease.version}\"' custom_components/diagral/manifest.json"
+              "prepareCmd": "npx node-jq '.version = \"${nextRelease.version}\"' custom_components/diagral/manifest.json > custom_components/diagral/manifest.json"
             }
         ],
         "@semantic-release/github",


### PR DESCRIPTION
* Ensure the `prepareCmd` correctly updates the `version` in `manifest.json`.
* Redirect output to the same file to apply changes effectively.