### PR TITLE
fix: 🔧 Update `prepareCmd` in `.releaserc` to use temporary manifest

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -18,7 +18,7 @@
         [
             "@semantic-release/exec",
             {
-              "prepareCmd": "npx node-jq '.version = \"${nextRelease.version}\"' custom_components/diagral/manifest.json > custom_components/diagral/manifest.json"
+              "prepareCmd": "npx node-jq '.version = \"${nextRelease.version}\"' custom_components/diagral/manifest.json > custom_components/diagral/manifest.tmp.json && mv custom_components/diagral/manifest.tmp.json custom_components/diagral/manifest.json"
             }
         ],
         "@semantic-release/github",


### PR DESCRIPTION
* Change the `prepareCmd` to create a temporary manifest file before replacing the original.
* This ensures that the original file is not corrupted during the update process.