### PR TITLE
fix: 🔧 Update `prepareCmd` in `.releaserc` to display temporary manifest

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -18,7 +18,7 @@
         [
             "@semantic-release/exec",
             {
-              "prepareCmd": "npx node-jq '.version = \"${nextRelease.version}\"' custom_components/diagral/manifest.json > custom_components/diagral/manifest.tmp.json && mv custom_components/diagral/manifest.tmp.json custom_components/diagral/manifest.json"
+              "prepareCmd": "npx node-jq '.version = \"${nextRelease.version}\"' custom_components/diagral/manifest.json > custom_components/diagral/manifest.tmp.json && cat custom_components/diagral/manifest.tmp.json"
             }
         ],
         "@semantic-release/github",


### PR DESCRIPTION
* Changed the `prepareCmd` to output the temporary manifest instead of moving it.
* This adjustment aids in verifying the changes before finalizing the manifest.