### PR TITLE
fix: 🔧 Update `release.yaml` and `.releaserc` for semantic-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install semantic-release
-        run: npm install -g semantic-release @semantic-release/github @semantic-release/commit-analyzer @semantic-release/git @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/exec node-jq
+        run: npm install -g semantic-release @semantic-release/github @semantic-release/commit-analyzer @semantic-release/git @semantic-release/release-notes-generator @semantic-release/changelog semantic-release-replace-plugin
       - name: Release
         id: semantic
         env:

--- a/.releaserc
+++ b/.releaserc
@@ -16,9 +16,24 @@
             }
         ],
         [
-            "@semantic-release/exec",
+            "semantic-release-replace-plugin",
             {
-              "prepareCmd": "cat <<< $(npx node-jq '.version = \"${nextRelease.version}\"' custom_components/diagral/manifest.json) > custom_components/diagral/manifest.json"
+              "replacements": [
+                {
+                  "files": ["custom_components/diagral/manifest.json"],
+                  "from": "\"version\": \".*\"",
+                  "to": "\"version\": \"${nextRelease.version}\"",
+                  "results": [
+                    {
+                      "file": "custom_components/diagral/manifest.json",
+                      "hasChanged": true,
+                      "numMatches": 1,
+                      "numReplacements": 1
+                    }
+                  ],
+                  "countMatches": true
+                }
+              ]
             }
         ],
         "@semantic-release/github",


### PR DESCRIPTION
* Added `semantic-release-replace-plugin` to the installation in `release.yaml`.
* Updated `prepareCmd` in `.releaserc` to use the new replacement configuration for manifest.json.