### PR TITLE
fix: Resolve issue with AddConfigEntryEntitiesCallback not already implemented in HA stable versions

### DIFF
--- a/.github/workflows/home-assistant.yaml
+++ b/.github/workflows/home-assistant.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   validate-hassfest:
-    name: hassfest Validation
+    name: Hassfest Validation
     runs-on: "ubuntu-latest"
     steps:
         - uses: "actions/checkout@v4"

--- a/.github/workflows/home-assistant.yaml
+++ b/.github/workflows/home-assistant.yaml
@@ -23,6 +23,7 @@ jobs:
         - uses: "home-assistant/actions/hassfest@master"
 
   validate-hacs:
+    name: HACS Validation
     runs-on: "ubuntu-latest"
     steps:
       - name: HACS validation

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
         {
             "file": ".github/copilot-commit-message-instructions.md"
         }
+    ],
+    "flake8.args": [
+        "--max-line-length=130"
     ]
 }

--- a/custom_components/diagral/alarm_control_panel.py
+++ b/custom_components/diagral/alarm_control_panel.py
@@ -15,7 +15,7 @@ from homeassistant.components.alarm_control_panel import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform, entity_registry as er
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DiagralConfigEntry
 from .const import DOMAIN, INPUT_GROUPS, SERVICE_ACTIVATE_GROUP, SERVICE_DISABLE_GROUP
@@ -29,7 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: DiagralConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Diagral Alarm Control Panel."""
     platform = entity_platform.async_get_current_platform()

--- a/custom_components/diagral/manifest.json
+++ b/custom_components/diagral/manifest.json
@@ -6,8 +6,8 @@
   "dependencies": ["alarm_control_panel", "cloud"],
   "documentation": "https://github.com/mguyard/hass-diagral",
   "integration_type": "hub",
-  "issue_tracker": "https://github.com/mguyard/hass-diagral/issues",
   "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/mguyard/hass-diagral/issues",
   "quality_scale": "bronze",
   "requirements": ["pydiagral==1.4.0"],
   "version": "1.0.0"

--- a/custom_components/diagral/manifest.json
+++ b/custom_components/diagral/manifest.json
@@ -6,6 +6,7 @@
   "dependencies": ["alarm_control_panel", "cloud"],
   "documentation": "https://github.com/mguyard/hass-diagral",
   "integration_type": "hub",
+  "issue_tracker": "https://github.com/mguyard/hass-diagral/issues",
   "iot_class": "cloud_polling",
   "quality_scale": "bronze",
   "requirements": ["pydiagral==1.4.0"],


### PR DESCRIPTION
This pull request includes various updates to improve validation, code quality, and maintainability across different files. The most important changes include adding a name to the HACS validation job, updating Flake8 settings, and **modifying the `Diagral` custom component to use a different callback type**.

### Validation and CI Improvements:

* [`.github/workflows/home-assistant.yaml`](diffhunk://#diff-5e7b83887ebb94a2dac651c5821f4eca0a7feffce459b72210e01ac1eb302d2fR26): Added a name to the HACS validation job for better identification in the workflow.

### Code Quality Enhancements:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R11-R13): Updated Flake8 settings to enforce a maximum line length of 130 characters.

### Custom Component Updates:

* [`custom_components/diagral/alarm_control_panel.py`](diffhunk://#diff-b68377ab22bdb091d87f4b28d563ef8dd51fb76a7a35f3605cd3285df52bf029L18-R18): Changed the import and usage of `AddConfigEntryEntitiesCallback` to `AddEntitiesCallback` for compatibility with the latest Home Assistant core. [[1]](diffhunk://#diff-b68377ab22bdb091d87f4b28d563ef8dd51fb76a7a35f3605cd3285df52bf029L18-R18) [[2]](diffhunk://#diff-b68377ab22bdb091d87f4b28d563ef8dd51fb76a7a35f3605cd3285df52bf029L32-R32)
* [`custom_components/diagral/manifest.json`](diffhunk://#diff-41715d8b4097fa8b3802fab755aab6cc0b57a49d92e2075c74f1a1d105469b9bR9): Added an issue tracker URL to the manifest for better issue management.