### PR TITLE
fix: Resolve issue with AddConfigEntryEntitiesCallback on binary_sensor & sensor platform

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,6 @@
         }
     ],
     "flake8.args": [
-        "--max-line-length=130"
+        "--max-line-length=150"
     ]
 }

--- a/custom_components/diagral/binary_sensor.py
+++ b/custom_components/diagral/binary_sensor.py
@@ -13,7 +13,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DiagralConfigEntry
 from .const import DOMAIN
@@ -43,7 +43,7 @@ BINARY_SENSORS: tuple[DiagralBinarySensorEntityDescription, ...] = (
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: DiagralConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Diagral binary sensor based on a config entry."""
     coordinator: DiagralDataUpdateCoordinator = entry.runtime_data.coordinator

--- a/custom_components/diagral/sensor.py
+++ b/custom_components/diagral/sensor.py
@@ -16,7 +16,7 @@ from pydiagral.models import (
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
 from . import DiagralConfigEntry
@@ -47,7 +47,7 @@ SENSORS: tuple[DiagralSensorEntityDescription, ...] = (
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: DiagralConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Diagral sensor based on a config entry."""
     coordinator: DiagralDataUpdateCoordinator = entry.runtime_data.coordinator


### PR DESCRIPTION
This pull request includes changes to update the maximum line length for Flake8 and to standardize the import of `AddEntitiesCallback` across multiple files in the `custom_components/diagral` directory.

Changes to Flake8 configuration:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L13-R13): Increased the maximum line length for Flake8 from 130 to 150.

Standardization of `AddEntitiesCallback` import:

* [`custom_components/diagral/binary_sensor.py`](diffhunk://#diff-aa975bbb6f3b7e8cf198ce57c46cc945e3a595043a7379702c2cf47cf2327004L16-R16): Replaced `AddConfigEntryEntitiesCallback` with `AddEntitiesCallback` in the import statement and the `async_setup_entry` method. [[1]](diffhunk://#diff-aa975bbb6f3b7e8cf198ce57c46cc945e3a595043a7379702c2cf47cf2327004L16-R16) [[2]](diffhunk://#diff-aa975bbb6f3b7e8cf198ce57c46cc945e3a595043a7379702c2cf47cf2327004L46-R46)
* [`custom_components/diagral/sensor.py`](diffhunk://#diff-0d8a756f094af0bf0e28c76b07a0a8506d5eb1200779c82dcd07b8b0a0412d22L19-R19): Replaced `AddConfigEntryEntitiesCallback` with `AddEntitiesCallback` in the import statement and the `async_setup_entry` method. [[1]](diffhunk://#diff-0d8a756f094af0bf0e28c76b07a0a8506d5eb1200779c82dcd07b8b0a0412d22L19-R19) [[2]](diffhunk://#diff-0d8a756f094af0bf0e28c76b07a0a8506d5eb1200779c82dcd07b8b0a0412d22L50-R50)