### PR TITLE
fix(webhook): 🔗 Handle existing webhook subscriptions gracefully

### DIFF
--- a/custom_components/diagral/__init__.py
+++ b/custom_components/diagral/__init__.py
@@ -161,6 +161,14 @@ async def register_webhook(
             except DiagralAPIError as err:
                 if "No subscription found for" in str(err):
                     pass
+                if "subscription already exists" in str(err):
+                    _LOGGER.warning(
+                        "A Webhook subscription already exists for another URL (%s). Integration will force update of webhook_url to %s",
+                        actual_webhook.webhook_url,
+                        webhook_url,
+                    )
+                    unregister_webhook(hass, entry, api, webhook_id, "register_webhook")
+                    register_webhook(hass, entry, api, "register_webhook")
                 else:
                     raise
 

--- a/docs/integration/webhook.mdx
+++ b/docs/integration/webhook.mdx
@@ -41,3 +41,14 @@ In case of any error, it will also be indicated in the Home Assistant logs.
 <Info>
 In case of error, you can try to restart the integration or use the actions [diagral.unregister_webhook](/integration/actions#register-webhook) and [diagral.register_webhook](/integration/actions#unregister-webhook) to force webhooks to reconfigure.
 </Info>
+
+## Existing subscription
+
+If a webhook subscription already exists for this installation (system ID) on a URL different from your Home Assistant's external URL, the integration will force the webhook URL to update.
+This can happen in various cases such as:
+- Using Diagral Webhook with systems other than this Home Assistant integration
+- A change in your external URL on your Home Assistant
+- After disabling Home Assistant Cloud to use direct external access or another access solution
+- etc...
+
+This scenario will trigger a warning message in your Home Assistant logs.


### PR DESCRIPTION
* Added a warning log when a webhook subscription already exists for a different URL.
* The integration will now force update the `webhook_url` if a subscription conflict is detected.
* Updated documentation to reflect the behavior when an existing subscription is found.