### PR TITLE
fix: Fix issue when webhook_url is already set in Diagral Cloud but not with HA URL

### DIFF
--- a/custom_components/diagral/__init__.py
+++ b/custom_components/diagral/__init__.py
@@ -141,16 +141,22 @@ async def register_webhook(
                 # Check if the webhook is already registered
                 actual_webhook = await api.get_webhook()
                 # If the webhook is already registered, update the URL
-                # or if no subscription found, pass
-                if actual_webhook is not None and actual_webhook.webhook_url.startswith(
-                    f"{external_url}/api/webhook/"
-                ):
-                    _LOGGER.info(
-                        "Webhook already registered for %s on %s. Updating URL to %s",
-                        entry.title,
-                        actual_webhook.webhook_url,
-                        webhook_url,
-                    )
+                if actual_webhook is not None:
+                    if actual_webhook.webhook_url.startswith(
+                        f"{external_url}/api/webhook/"
+                    ):
+                        _LOGGER.info(
+                            "Webhook already registered for %s on %s. Updating URL to %s",
+                            entry.title,
+                            actual_webhook.webhook_url,
+                            webhook_url,
+                        )
+                    else:
+                        _LOGGER.warning(
+                            "A Webhook subscription already exists for another URL (%s). Integration will force update of webhook_url to %s",
+                            actual_webhook.webhook_url,
+                            webhook_url,
+                        )
                     await api.update_webhook(
                         webhook_url=webhook_url,
                         subscribe_to_anomaly=True,
@@ -161,14 +167,6 @@ async def register_webhook(
             except DiagralAPIError as err:
                 if "No subscription found for" in str(err):
                     pass
-                if "subscription already exists" in str(err):
-                    _LOGGER.warning(
-                        "A Webhook subscription already exists for another URL (%s). Integration will force update of webhook_url to %s",
-                        actual_webhook.webhook_url,
-                        webhook_url,
-                    )
-                    unregister_webhook(hass, entry, api, webhook_id, "register_webhook")
-                    register_webhook(hass, entry, api, "register_webhook")
                 else:
                     raise
 

--- a/docs/integration/webhook.mdx
+++ b/docs/integration/webhook.mdx
@@ -44,7 +44,7 @@ In case of error, you can try to restart the integration or use the actions [dia
 
 ## Existing subscription
 
-If a webhook subscription already exists for this installation (system ID) on a URL different from your Home Assistant's external URL, the integration will force the webhook URL to update.
+If a webhook subscription already exists for this installation (system ID) on a URL different from your Home Assistant's external URL, the `integration will force the webhook URL to update`.
 This can happen in various cases such as:
 - Using Diagral Webhook with systems other than this Home Assistant integration
 - A change in your external URL on your Home Assistant


### PR DESCRIPTION
This pull request includes changes to the `register_webhook` function in `custom_components/diagral/__init__.py` and updates to the documentation in `docs/integration/webhook.mdx`. The changes improve the handling of webhook subscriptions and clarify the documentation.

Improvements to webhook subscription handling:

* [`custom_components/diagral/__init__.py`](diffhunk://#diff-ef9d36668cb9b1dc331698b0e49d1d5ff87c0169e0d2ab67fe3680d6c1886daeL144-R145): Modified the `register_webhook` function to add a warning log if a webhook subscription already exists for another URL and to remove redundant code that re-registers the webhook upon encountering a specific error. [[1]](diffhunk://#diff-ef9d36668cb9b1dc331698b0e49d1d5ff87c0169e0d2ab67fe3680d6c1886daeL144-R145) [[2]](diffhunk://#diff-ef9d36668cb9b1dc331698b0e49d1d5ff87c0169e0d2ab67fe3680d6c1886daeR154-R159) [[3]](diffhunk://#diff-ef9d36668cb9b1dc331698b0e49d1d5ff87c0169e0d2ab67fe3680d6c1886daeL164-L171)

Documentation updates:

* [`docs/integration/webhook.mdx`](diffhunk://#diff-664e278980a18b92fd962033c97496c62114f05b1dcf97b24cb9c8832b5a9584L47-R47): Clarified that the integration will force the webhook URL to update if a subscription already exists for a different URL.