### PR TITLE
docs(issues): ✏️ Add missing closing backtick in logging instructions

### DIFF
--- a/docs/issues/index.mdx
+++ b/docs/issues/index.mdx
@@ -43,6 +43,7 @@ logger:
   logs:
     custom_components.diagral: debug
     pydiagral.api: debug // [!code highlight]
+```
 </Card>
 
 ## Declare issue


### PR DESCRIPTION
* Ensures proper formatting in the documentation for `logger` section.
* Improves clarity and prevents potential rendering issues.