### PR TITLE
fix: Fix forgotten condition for property code_arm_required and change HA minimal version for HACS

### DIFF
--- a/custom_components/diagral/alarm_control_panel.py
+++ b/custom_components/diagral/alarm_control_panel.py
@@ -152,6 +152,11 @@ class DiagralAlarmControlPanel(DiagralEntity, AlarmControlPanelEntity):
     @property
     def code_arm_required(self) -> bool:
         """Whether the code is required for arm actions."""
+        if (
+            self._config.options.alarmpanel_options[CONF_ALARMPANEL_ACTIONTYPE_CODE]
+            != "never"
+        ):
+            return True
         return False
 
     @property

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Diagral",
     "country": "FR",
-    "homeassistant": "2024.9.0"
+    "homeassistant": "2025.2.0"
 }


### PR DESCRIPTION
This pull request includes changes to the `Diagral` integration for Home Assistant. The most important changes include updating the `code_arm_required` property logic and modifying the `homeassistant` version in `hacs.json`.

Improvements to `Diagral` integration:

* [`custom_components/diagral/alarm_control_panel.py`](diffhunk://#diff-b68377ab22bdb091d87f4b28d563ef8dd51fb76a7a35f3605cd3285df52bf029R155-R159): Updated the `code_arm_required` property to check the `alarmpanel_options` configuration and return `True` if the `CONF_ALARMPANEL_ACTIONTYPE_CODE` is not set to "never".

Configuration update:

* [`hacs.json`](diffhunk://#diff-2004f3033aaa650b74a155b56a1e6110e85583824c83f3cb5a0c2856bd00483fL4-R4): Updated the `homeassistant` version requirement from `2024.9.0` to `2025.2.0`.