### PR TITLE
docs: 📝 Update serial number length in setup documentation

### DIFF
--- a/docs/integration/setup.mdx
+++ b/docs/integration/setup.mdx
@@ -46,7 +46,7 @@ Choose your account type carefully based on your specific needs.
 
 The serial number is located inside your Diagral box.
 To access it, open the box and locate a label with a QR code.
-You'll find a 15-character code - this is your box's serial number.
+You'll find a 14-character code - this is your box's serial number.
 
 <Image src="https://raw.githubusercontent.com/mguyard/pydiagral/main/docs/how-to-find-diagral-serial.png" alt="Location of System Serial ID"/>
 


### PR DESCRIPTION
* Corrected the serial number length from 15 to 14 characters.
* Ensures accurate information for users accessing their Diagral box.