### PR TITLE
fix: Fix webhook registration to NabuCasa in case of webhook update

### DIFF
--- a/docs/faq/index.mdx
+++ b/docs/faq/index.mdx
@@ -17,6 +17,19 @@ To change your credentials, go to [the integration configuration](https://my.hom
 To enable/disable this feature, go to [the integration configuration](https://my.home-assistant.io/redirect/integration/?domain=diagral), click on `Configure` and you'll find the settings under `Alarm Panel Options`.
 </Accordion>
 
+## Behavior
+
+### Required code doesn't match my configuration
+
+<Accordion title="What is the reason" icon="question">
+You have configured the integration to require a code only when disarming. However, when you arm your alarm, the code is requested.
+This is normal behavior because Home Assistant works this way with its `Alarm Control Panel` platform. Indeed, to detect if a code is required, Home Assistant checks the `code_arm_required` attribute.
+If it's True, then a code must be requested. However, Home Assistant is not able to request it only for disarming (at least for now).
+
+Nevertheless, the code is only verified for the actions you have [configured](/integration/setup#alarm-panel-options).
+Therefore, if you have configured a code required only for disarming, you can enter any code (even a wrong one) for activation.
+</Accordion>
+
 ## Errors
 
 ### Session already opened


### PR DESCRIPTION
This pull request includes changes to the `custom_components/diagral` integration and updates to the documentation. The most important changes include importing the `urlparse` module, adding comments and debug logs to the `register_webhook` function, and updating the FAQ documentation.

Code improvements in `custom_components/diagral`:

* [`custom_components/diagral/__init__.py`](diffhunk://#diff-ef9d36668cb9b1dc331698b0e49d1d5ff87c0169e0d2ab67fe3680d6c1886daeR7): Imported the `urlparse` module to parse URLs.
* [`custom_components/diagral/__init__.py`](diffhunk://#diff-ef9d36668cb9b1dc331698b0e49d1d5ff87c0169e0d2ab67fe3680d6c1886daeR102): Added comments and debug logs in the `register_webhook` function to improve clarity and traceability. [[1]](diffhunk://#diff-ef9d36668cb9b1dc331698b0e49d1d5ff87c0169e0d2ab67fe3680d6c1886daeR102) [[2]](diffhunk://#diff-ef9d36668cb9b1dc331698b0e49d1d5ff87c0169e0d2ab67fe3680d6c1886daeL142-R157)

Documentation updates:

* [`docs/faq/index.mdx`](diffhunk://#diff-080b51bc7769f243741bd774fd930307b2265921ba3d1e8d3c46c03321b36326R20-R32): Added a new section under "Behavior" to explain why a code is requested when arming the alarm even if it is configured to require a code only when disarming.