### PR TITLE
feat(alarm_control_panel): ✨ enhance code requirement logic

### DIFF
--- a/custom_components/diagral/translations/en.json
+++ b/custom_components/diagral/translations/en.json
@@ -51,6 +51,9 @@
                         "data": {
                             "alarmpanel_actiontype_code": "When do you want the security code to be required?",
                             "alarmpanel_code": "Alarm Panel Code (minimum of four digits - leave empty for no PIN)"
+                        },
+                        "data_description": {
+                            "alarmpanel_actiontype_code": "You can define when the code is required to arm/disarm your alarm. If you set it to `Never`, the code will never be required. If you set it to `To disarm only`, the code will only be required to disarm the alarm. If you set it to `To arm and disarm`, the code will be required for both arming and disarming the alarm."
                         }
                     }
                 }

--- a/custom_components/diagral/translations/fr.json
+++ b/custom_components/diagral/translations/fr.json
@@ -50,6 +50,9 @@
                         "data": {
                             "alarmpanel_actiontype_code": "Quand voulez-vous que le code de sécurité soit exigé ?",
                             "alarmpanel_code": "Code du panneau d'alarme (minimum quatre chiffres - laisser vide pour ne pas activer la fonctionnalité)"
+                        },
+                        "data_description": {
+                            "alarmpanel_actiontype_code": "Vous pouvez définir quand le code est requis pour armer/désarmer votre alarme. Si vous le configurez sur `Jamais`, le code ne sera jamais demandé. Si vous le configurez sur `Pour désarmer uniquement`, le code sera uniquement demandé pour désarmer l'alarme. Si vous le configurez sur `Pour armer et désarmer`, le code sera demandé à la fois pour armer et désarmer l'alarme."
                         }
                     }
                 }

--- a/docs/faq/index.mdx
+++ b/docs/faq/index.mdx
@@ -17,19 +17,6 @@ To change your credentials, go to [the integration configuration](https://my.hom
 To enable/disable this feature, go to [the integration configuration](https://my.home-assistant.io/redirect/integration/?domain=diagral), click on `Configure` and you'll find the settings under `Alarm Panel Options`.
 </Accordion>
 
-## Behavior
-
-### Required code doesn't match my configuration
-
-<Accordion title="What is the reason" icon="question">
-You have configured the integration to require a code only when disarming. However, when you arm your alarm, the code is requested.
-This is normal behavior because Home Assistant works this way with its `Alarm Control Panel` platform. Indeed, to detect if a code is required, Home Assistant checks the `code_arm_required` attribute.
-If it's True, then a code must be requested. However, Home Assistant is not able to request it only for disarming (at least for now).
-
-Nevertheless, the code is only verified for the actions you have [configured](/integration/setup#alarm-panel-options).
-Therefore, if you have configured a code required only for disarming, you can enter any code (even a wrong one) for activation.
-</Accordion>
-
 ## Errors
 
 ### Session already opened


### PR DESCRIPTION
This pull request focuses on improving the handling of the security code requirement for the alarm control panel in the `diagral` custom component. The changes include refactoring the code to centralize the logic for determining when the code is required and updating the documentation to reflect these changes.

In this way, code is only requested when it is really needed according to the defined configuration.

Key changes include:

### Code Refactoring:

* Added `_is_code_arm_required` method to centralize the logic for determining when the security code is required (`custom_components/diagral/alarm_control_panel.py`).
* Updated the `__init__` method to use `_is_code_arm_required` for setting `_attr_code_arm_required` (`custom_components/diagral/alarm_control_panel.py`).
* Removed the `code_arm_required` property and updated the `code_format` property to use `_is_code_arm_required` (`custom_components/diagral/alarm_control_panel.py`).
* Updated `_handle_coordinator_update` method to refresh `_attr_code_arm_required` on state changes (`custom_components/diagral/alarm_control_panel.py`).

### Documentation Updates:

* Added descriptions for `alarmpanel_actiontype_code` in English and French translations to explain when the code is required (`custom_components/diagral/translations/en.json`, `custom_components/diagral/translations/fr.json`). [[1]](diffhunk://#diff-8245ec49cc56866d520a2a8e8aeb0eccc3c198fef32ddbfada5558dde3b38fbbR54-R56) [[2]](diffhunk://#diff-f737a58d8b189651d64f2bd706087a37e7dd0023c66dae23a5b5a09b1e481635R53-R55)
* Removed outdated FAQ section about code requirement behavior (`docs/faq/index.mdx`).