### PR TITLE
fix(diagral): 🐛 update `pydiagral` requirement to version 1.5.2

### DIFF
--- a/custom_components/diagral/manifest.json
+++ b/custom_components/diagral/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/mguyard/hass-diagral/issues",
   "quality_scale": "bronze",
-  "requirements": ["pydiagral==1.5.1"],
+  "requirements": ["pydiagral==1.5.2"],
   "version": "1.1.0-beta.13"
 }

--- a/custom_components/diagral/sensor.py
+++ b/custom_components/diagral/sensor.py
@@ -246,7 +246,7 @@ class DiagralSensor(DiagralEntity, SensorEntity):
 
         if system_status.status == "PRESENCE":
             # If the system is in presence mode, we grab the groups from the alarm configuration
-            group_list = alarm_config.grp_marche_presence
+            group_list = alarm_config.presence_group
         else:
             # Otherwise, count the number of activated groups
             group_list = system_status.activated_groups


### PR DESCRIPTION
This pull request includes updates to the `custom_components/diagral` component to improve functionality and ensure compatibility with the latest library versions. The most important changes include updating the `pydiagral` library version and modifying the group list retrieval logic in the sensor component.

Library version update:

* [`custom_components/diagral/manifest.json`](diffhunk://#diff-41715d8b4097fa8b3802fab755aab6cc0b57a49d92e2075c74f1a1d105469b9bL12-R12): Updated the `pydiagral` requirement from version 1.5.1 to 1.5.2.

Group list retrieval logic:

* [`custom_components/diagral/sensor.py`](diffhunk://#diff-0d8a756f094af0bf0e28c76b07a0a8506d5eb1200779c82dcd07b8b0a0412d22L249-R249): Changed the variable `group_list` to use `alarm_config.presence_group` instead of `alarm_config.grp_marche_presence` when the system status is "PRESENCE".