### PR TITLE
feat(config): ✨ Allow support of pincode starting with one or more 0

### DIFF
--- a/custom_components/diagral/__init__.py
+++ b/custom_components/diagral/__init__.py
@@ -34,6 +34,7 @@ from .const import (
     CONF_PIN_CODE,
     CONF_SECRET_KEY,
     CONF_SERIAL_ID,
+    CONFIG_VERSION,
     DOMAIN,
     HA_CLOUD_DOMAIN,
 )
@@ -87,6 +88,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: DiagralConfigEntry) -> b
         return False
     else:
         return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: DiagralConfigEntry):
+    """Migrate the config entry to a new version."""
+    _LOGGER.debug(
+        "Migrating configuration from version %s.%s",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
+    if config_entry.version > CONFIG_VERSION:
+        # This means the user has downgraded from a future version
+        return False
+
+    if config_entry.version == 1:
+        new_data = {**config_entry.data}
+        if config_entry.minor_version == 1:
+            new_data[CONF_PIN_CODE] = str(config_entry.data[CONF_PIN_CODE])
+
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, minor_version=3, version=1
+        )
+
+    return True
 
 
 async def register_webhook(

--- a/custom_components/diagral/config_flow.py
+++ b/custom_components/diagral/config_flow.py
@@ -36,6 +36,8 @@ from .const import (
     CONF_PIN_CODE,
     CONF_SECRET_KEY,
     CONF_SERIAL_ID,
+    CONFIG_MINOR_VERSION,
+    CONFIG_VERSION,
     DOMAIN,
 )
 from .models import AccountInfoData, DiagralOptionsData, ValidateConnectionData
@@ -49,9 +51,12 @@ def is_valid_email(email: str) -> bool:
     return re.match(pattern, email) is not None
 
 
-def is_valid_pin(pin: int) -> bool:
-    """Check if the PIN is valid (positive integer)."""
-    return isinstance(pin, int) and pin >= 0
+def is_valid_pin(pin: str) -> bool:
+    """Check if the pin code is valid.
+
+    The pin code must be a string of digits and must be greater than or equal to 0.
+    """
+    return isinstance(pin, str) and pin.isdigit() and int(pin) >= 0
 
 
 def is_valid_alarmpanel_code(code: int) -> bool:
@@ -130,8 +135,8 @@ async def validate_account(
 class DiagralConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Diagral."""
 
-    VERSION = 1
-    MINOR_VERSION = 1
+    VERSION = CONFIG_VERSION
+    MINOR_VERSION = CONFIG_MINOR_VERSION
 
     def __init__(self):
         """Initialize the config flow."""
@@ -140,7 +145,7 @@ class DiagralConfigFlow(ConfigFlow, domain=DOMAIN):
         self.title: str | None = None
         self.account_username: str | None = None
         self.account_password: str | None = None
-        self.account_pincode: int | None = None
+        self.account_pincode: str | None = None
         self.apikey: str | None = None
         self.secretkey: str | None = None
 
@@ -228,7 +233,7 @@ class DiagralConfigFlow(ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_USERNAME): str,
                 vol.Required(CONF_PASSWORD): str,
-                vol.Required(CONF_PIN_CODE, default=None): vol.Coerce(int),
+                vol.Required(CONF_PIN_CODE, default=None): str,
             }
         )
 
@@ -420,7 +425,7 @@ class DiagralConfigFlow(ConfigFlow, domain=DOMAIN):
                 ): str,
                 vol.Required(
                     CONF_PIN_CODE, default=config_entry.data[CONF_PIN_CODE]
-                ): vol.Coerce(int),
+                ): str,
             }
         )
 

--- a/custom_components/diagral/const.py
+++ b/custom_components/diagral/const.py
@@ -3,6 +3,9 @@
 DOMAIN = "diagral"
 BRAND = "Diagral"
 
+CONFIG_VERSION = 2
+CONFIG_MINOR_VERSION = 1
+
 CONF_SERIAL_ID = "serial_id"
 CONF_PIN_CODE = "pin_code"
 CONF_API_KEY = "api_key"

--- a/custom_components/diagral/manifest.json
+++ b/custom_components/diagral/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/mguyard/hass-diagral/issues",
   "quality_scale": "bronze",
-  "requirements": ["pydiagral==1.5.2"],
+  "requirements": ["pydiagral==1.6.0-beta.1"],
   "version": "1.1.0"
 }


### PR DESCRIPTION
This pull request includes several changes to the `diagral` custom component, focusing on configuration migration, version updates, and validation improvements.

### Configuration Migration and Version Updates:

* [`custom_components/diagral/__init__.py`](diffhunk://#diff-ef9d36668cb9b1dc331698b0e49d1d5ff87c0169e0d2ab67fe3680d6c1886daeR37): Added `CONFIG_VERSION` and implemented `async_migrate_entry` to handle configuration migration to new versions. [[1]](diffhunk://#diff-ef9d36668cb9b1dc331698b0e49d1d5ff87c0169e0d2ab67fe3680d6c1886daeR37) [[2]](diffhunk://#diff-ef9d36668cb9b1dc331698b0e49d1d5ff87c0169e0d2ab67fe3680d6c1886daeR93-R116)
* [`custom_components/diagral/const.py`](diffhunk://#diff-1b2583f95951b4e349ca6b4f83ddb56ac5c721afc2c7d8588183f1483134e846R6-R8): Defined `CONFIG_VERSION` and `CONFIG_MINOR_VERSION`.
* [`custom_components/diagral/config_flow.py`](diffhunk://#diff-0492850f71a8be9cd1b648d641e37c33bd253b364bc5a2e56236d4805f24da7dL133-R139): Updated `VERSION` and `MINOR_VERSION` to use `CONFIG_VERSION` and `CONFIG_MINOR_VERSION`.

### Validation Improvements:

* [`custom_components/diagral/config_flow.py`](diffhunk://#diff-0492850f71a8be9cd1b648d641e37c33bd253b364bc5a2e56236d4805f24da7dL52-R59): Modified `is_valid_pin` to validate PIN as a string of digits and updated references to `CONF_PIN_CODE` to handle it as a string instead of an integer. [[1]](diffhunk://#diff-0492850f71a8be9cd1b648d641e37c33bd253b364bc5a2e56236d4805f24da7dL52-R59) [[2]](diffhunk://#diff-0492850f71a8be9cd1b648d641e37c33bd253b364bc5a2e56236d4805f24da7dL143-R148) [[3]](diffhunk://#diff-0492850f71a8be9cd1b648d641e37c33bd253b364bc5a2e56236d4805f24da7dL231-R236) [[4]](diffhunk://#diff-0492850f71a8be9cd1b648d641e37c33bd253b364bc5a2e56236d4805f24da7dL423-R428)

### Dependency Update:

* [`custom_components/diagral/manifest.json`](diffhunk://#diff-41715d8b4097fa8b3802fab755aab6cc0b57a49d92e2075c74f1a1d105469b9bL12-R12): Updated the `pydiagral` dependency to version `1.6.0-beta.1`.