### PR TITLE
fix(alarm_control_panel): 🐛 Fix code support for TRIGGERED state

### DIFF
--- a/.github/workflows/labelers.yml
+++ b/.github/workflows/labelers.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v5.2.0
+        uses: crazy-max/ghaction-github-labeler@v5.3.0
         with:
           skip-delete: true

--- a/custom_components/diagral/alarm_control_panel.py
+++ b/custom_components/diagral/alarm_control_panel.py
@@ -189,6 +189,7 @@ class DiagralAlarmControlPanel(DiagralEntity, AlarmControlPanelEntity):
                 AlarmControlPanelState.ARMING,
                 AlarmControlPanelState.ARMED_AWAY,
                 AlarmControlPanelState.ARMED_HOME,
+                AlarmControlPanelState.TRIGGERED,
             ):
                 return True
             return False  # If the alarm is disarmed, don't require code


### PR DESCRIPTION
This pull request includes updates to a GitHub Actions workflow and a minor fix to the alarm control panel code in the `diagral` custom component.

### Workflow Updates:
* [`.github/workflows/labelers.yml`](diffhunk://#diff-3d214633a6040f9f9bbd08b420279a4df8288307685e6b22b17de20e1f1eaeddL19-R19): Updated the `ghaction-github-labeler` action from version `v5.2.0` to `v5.3.0`.

### Code Fix:
* [`custom_components/diagral/alarm_control_panel.py`](diffhunk://#diff-b68377ab22bdb091d87f4b28d563ef8dd51fb76a7a35f3605cd3285df52bf029R192): Add `AlarmControlPanelState.TRIGGERED` to the list of states that require a code when arming the alarm.