### PR TITLE
fix(webhook): 🐛 Avoid error with inactive cloud subscription for webhook creation

### DIFF
--- a/custom_components/diagral/__init__.py
+++ b/custom_components/diagral/__init__.py
@@ -151,9 +151,11 @@ async def register_webhook(
                 if cloud_active_subscription(hass):
                     webhook_url = await cloud_get_or_create_cloudhook(hass, webhook_id)
                 else:
+                    # If the cloud subscription is not active, we cannot create a webhook
                     _LOGGER.error(
                         "Cloud subscription not active. Webhook will not be created"
                     )
+                    return None
             except (CloudNotConnected, CloudNotAvailable):
                 _LOGGER.error(
                     "Cloud not connected or not available. Webhook will not be created"


### PR DESCRIPTION
This pull request includes a minor update to the `register_webhook` function in the `custom_components/diagral/__init__.py` file. The change adds a comment to clarify that a webhook cannot be created if the cloud subscription is not active and ensures the function returns `None` in this case to avoid to trigger a code error detected during issue #42.

* [`custom_components/diagral/__init__.py`](diffhunk://#diff-ef9d36668cb9b1dc331698b0e49d1d5ff87c0169e0d2ab67fe3680d6c1886daeR154-R158): Added a comment and a return statement to handle the scenario where the cloud subscription is not active in the `register_webhook` function.