### PR TITLE
docs(faq): ✏️ Add explanation for webhook creation error due to inactive cloud subscription

### DIFF
--- a/docs/faq/index.mdx
+++ b/docs/faq/index.mdx
@@ -19,6 +19,16 @@ To enable/disable this feature, go to [the integration configuration](https://my
 
 ## Errors
 
+### Cloud subscription not active. Webhook will not be created
+
+<Accordion title="What is the reason" icon="question">
+The Diagral integration automatically detects your Home Assistant configuration compatible with receiving a [Webhook](/integration/webhook) from Diagral servers.<br /><br />
+This error message indicates that according to Home Assistant, the only method meeting the [prerequisites](/integration/webhook#home-assistant-url) and allowing to receive a webhook from Diagral is through `Home Assistant Cloud` from [Nabu Casa](https://www.nabucasa.com) but your Home Assistant Cloud subscription is no longer valid (but still configured on your Home Assistant) or you are experiencing connectivity issues between your Home Assistant and Home Assistant Cloud.<br />
+In any case, the Diagral integration cannot create the Webhook through Home Assistant Cloud.
+
+`How to solve?`: Depending on your situation, either renew your subscription/fix the connectivity issue with Home Assistant Cloud, or configure your Home Assistant to stop using Home Assistant Cloud and use another connection solution such as direct access, [NGINX](https://nginx.org) or [DuckDns](http://www.duckdns.org) for example that meets the [prerequisites](/integration/webhook#home-assistant-url).
+</Accordion>
+
 ### Session already opened
 
 <Accordion title="What is the reason" icon="question">

--- a/docs/integration/webhook.mdx
+++ b/docs/integration/webhook.mdx
@@ -21,9 +21,9 @@ To benefit from webhooks, you need a Home Assistant instance that is `accessible
 [![Open your Home Assistant instance and manage your systems network configuration.](https://my.home-assistant.io/badges/network.svg)](https://my.home-assistant.io/redirect/network/)
 <Image src="/images/external-access.png" alt="External Access Configuration" />
 
-The integration can use the connection through Home Assistant Cloud.
+The integration can use the connection through Home Assistant Cloud provided by [Nabu Casa](https://www.nabucasa.com).
 
-However, if you have both an external access and a Home Assistant Cloud subscription, priority will be given to external access.
+However, if you have both an external access and a Home Assistant Cloud subscription, priority will be given to external access (if both access methods meet the prerequisites mentioned at the beginning of this section).
 
 ## Implementation
 


### PR DESCRIPTION
This pull request includes updates to the documentation to provide more clarity on the requirements (#42) and troubleshooting steps for using webhooks with Home Assistant. The changes primarily focus on the integration with Home Assistant Cloud and alternative connection solutions.

Documentation updates:

* [`docs/faq/index.mdx`](diffhunk://#diff-080b51bc7769f243741bd774fd930307b2265921ba3d1e8d3c46c03321b36326R22-R31): Added a new section to explain the error message "Cloud subscription not active. Webhook will not be created" and provided detailed troubleshooting steps for resolving the issue.
* [`docs/integration/webhook.mdx`](diffhunk://#diff-664e278980a18b92fd962033c97496c62114f05b1dcf97b24cb9c8832b5a9584L24-R26): Clarified that the integration can use the connection through Home Assistant Cloud provided by Nabu Casa, and specified the priority rules when both external access and Home Assistant Cloud subscription are available.