### PR TITLE
feat(alarm_control_panel): ✨ Add additional alarm code for trigger state

### DIFF
--- a/custom_components/diagral/alarm_control_panel.py
+++ b/custom_components/diagral/alarm_control_panel.py
@@ -343,7 +343,10 @@ class DiagralAlarmControlPanel(DiagralEntity, AlarmControlPanelEntity):
         """Handle incoming event for ALERT events."""
         _LOGGER.debug("%s received event: %s", self.name, event)
         event_alarm_code = int(event["data"].get("alarm_code"))
-        ALARM_INTRUSION_CODES = {1130, 1139}
+        # 1130 : INTRUSION
+        # 1139 : INTRUSION-CONFIRMED
+        # 1141 : PREALARM-CONFIRMED
+        ALARM_INTRUSION_CODES = {1130, 1139, 1141}
         if event_alarm_code in ALARM_INTRUSION_CODES:
             # Set the group name and id
             groups: list[Group] = self._alarm_config.groups

--- a/custom_components/diagral/diagnostics.py
+++ b/custom_components/diagral/diagnostics.py
@@ -1,4 +1,4 @@
-"""Diagnostics support for Netatmo."""
+"""Diagnostics support for Diagral."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
This pull request updates the `Diagral` custom component to enhance functionality and correct a minor documentation issue. The most important changes include extending the set of alarm codes handled in the `alarm_control_panel` module and fixing a mislabeling in the diagnostics module.

### Enhancements to alarm handling:
* [`custom_components/diagral/alarm_control_panel.py`](diffhunk://#diff-b68377ab22bdb091d87f4b28d563ef8dd51fb76a7a35f3605cd3285df52bf029L346-R349): Added a new alarm code (`1141`) to the `ALARM_INTRUSION_CODES` set, which now includes `1130` (INTRUSION), `1139` (INTRUSION-CONFIRMED), and `1141` (PREALARM-CONFIRMED). This ensures the system can handle an additional type of alert event.

### Documentation correction:
* [`custom_components/diagral/diagnostics.py`](diffhunk://#diff-a0e9d84bfc2ba087fee0bad11f59c8442591dee82af668a3e347fe567d293ab5L1-R1): Updated the module docstring to correctly reference "Diagral", fixing a copy-paste error.