### PR TITLE
docs(entities): 📝 Clarify `triggered` state description and add alert types

### DIFF
--- a/docs/integration/entities.mdx
+++ b/docs/integration/entities.mdx
@@ -35,7 +35,7 @@ States :
 
 ### Triggered state
 
-The `triggered` state is not a proper alarm state but is activated when receiving an ALERT [webhook](/integration/webhook) (alarm_code 1130, 1139) from Diagral Cloud.
+The `triggered` state is not a proper alarm state but is activated when receiving an ALERT [webhook](/integration/webhook) from Diagral Cloud.
 The `triggered` status is only removed when the alarm is disarmed.
 When the triggered state is activated, the entity contains attributes (if available in the webhook):
 
@@ -44,6 +44,11 @@ trigger:
   group_name: Motion Sensors
   group_id: 3
 ```
+
+Alert type supported :
+- `1130` : INTRUSION
+- `1139` : INTRUSION-CONFIRMED
+- `1141` : PREALARM-CONFIRMED
 
 ## Anomalies - Details
 


### PR DESCRIPTION
This pull request updates the documentation in `docs/integration/entities.mdx` to clarify the `triggered` state and add details about supported alert types.

Changes to the `triggered` state:

* Removed specific alert codes (`1130`, `1139`) from the description of the `triggered` state, as they are now detailed separately in the supported alert types section.

Addition of supported alert types:

* Added a new section listing supported alert types, including `1130` (INTRUSION), `1139` (INTRUSION-CONFIRMED), and `1141` (PREALARM-CONFIRMED).