### PR TITLE
fix(docs): 📝 Update HACS integration instructions

### DIFF
--- a/docs/integration/index.mdx
+++ b/docs/integration/index.mdx
@@ -18,16 +18,6 @@ Once HACS is installed, simple click the button below to start the automated ins
 
 ## Via HACS UI
 
-<!-- `Diagral` is a default repository within HACS.  If you do not wish to use the automatic install, you can search for `Diagral` within the HACS interface -->
-
 <Info>
-  The Diagral integration has not yet been validated by HACS to be part of its default repositories.
-  Therefore, it is necessary to manually add the GitHub repository of the Diagral integration or use the automatic method described above.
+  `Diagral` is a default repository within HACS.  If you do not wish to use the automatic install, you can search for `Diagral` within the HACS interface
 </Info>
-
-<Card title="Integration Repository" icon="cog">
-  [Manually add this repository](https://www.hacs.xyz/docs/faq/custom_repositories/) to HACS if you prefer not to use the automated installation below:
-    ```text
-    https://github.com/mguyard/hass-diagral
-    ````
-</Card>


### PR DESCRIPTION
This pull request updates the documentation for the `Diagral` integration in the HACS UI section. The changes clarify that `Diagral` is now a default repository within HACS, removing outdated instructions for manual repository addition.

Key documentation update:

* [`docs/integration/index.mdx`](diffhunk://#diff-76a24c56e8ea7b02e2b2a808606aa8a69e52a6ed5d191b346bf561155ce8da40L21-L33): Updated the `Info` section to reflect that `Diagral` is a default repository in HACS, and removed obsolete instructions for manually adding the repository.