### PR TITLE
chore(publish): Publish New Stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.3.0-beta.2](https://github.com/mguyard/hass-diagral/compare/v1.3.0-beta.1...v1.3.0-beta.2) (2025-06-03)
+
+
+### Bug Fixes
+
+* **docs:** 📝 Update HACS integration instructions ([f9e3651](https://github.com/mguyard/hass-diagral/commit/f9e3651a9f0efa3f2bbad2c7f52b9b62af5ef290))
+
 # [1.3.0-beta.1](https://github.com/mguyard/hass-diagral/compare/v1.2.0...v1.3.0-beta.1) (2025-05-20)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.3.0-beta.1](https://github.com/mguyard/hass-diagral/compare/v1.2.0...v1.3.0-beta.1) (2025-05-20)
+
+
+### Features
+
+* **alarm_control_panel:** ✨ Add additional alarm code for trigger state ([7fe6a77](https://github.com/mguyard/hass-diagral/commit/7fe6a77e4d1d7b1074ceb10c3e5e53f4756b3576))
+
 # [1.2.0](https://github.com/mguyard/hass-diagral/compare/v1.1.0...v1.2.0) (2025-05-02)
 
 

--- a/custom_components/diagral/alarm_control_panel.py
+++ b/custom_components/diagral/alarm_control_panel.py
@@ -343,7 +343,10 @@ class DiagralAlarmControlPanel(DiagralEntity, AlarmControlPanelEntity):
         """Handle incoming event for ALERT events."""
         _LOGGER.debug("%s received event: %s", self.name, event)
         event_alarm_code = int(event["data"].get("alarm_code"))
-        ALARM_INTRUSION_CODES = {1130, 1139}
+        # 1130 : INTRUSION
+        # 1139 : INTRUSION-CONFIRMED
+        # 1141 : PREALARM-CONFIRMED
+        ALARM_INTRUSION_CODES = {1130, 1139, 1141}
         if event_alarm_code in ALARM_INTRUSION_CODES:
             # Set the group name and id
             groups: list[Group] = self._alarm_config.groups

--- a/custom_components/diagral/diagnostics.py
+++ b/custom_components/diagral/diagnostics.py
@@ -1,4 +1,4 @@
-"""Diagnostics support for Netatmo."""
+"""Diagnostics support for Diagral."""
 
 from __future__ import annotations
 

--- a/custom_components/diagral/manifest.json
+++ b/custom_components/diagral/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/mguyard/hass-diagral/issues",
   "quality_scale": "bronze",
   "requirements": ["pydiagral==1.6.0"],
-  "version": "1.2.0"
+  "version": "1.3.0-beta.1"
 }

--- a/custom_components/diagral/manifest.json
+++ b/custom_components/diagral/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/mguyard/hass-diagral/issues",
   "quality_scale": "bronze",
   "requirements": ["pydiagral==1.6.0"],
-  "version": "1.3.0-beta.1"
+  "version": "1.3.0-beta.2"
 }

--- a/docs/integration/entities.mdx
+++ b/docs/integration/entities.mdx
@@ -35,7 +35,7 @@ States :
 
 ### Triggered state
 
-The `triggered` state is not a proper alarm state but is activated when receiving an ALERT [webhook](/integration/webhook) (alarm_code 1130, 1139) from Diagral Cloud.
+The `triggered` state is not a proper alarm state but is activated when receiving an ALERT [webhook](/integration/webhook) from Diagral Cloud.
 The `triggered` status is only removed when the alarm is disarmed.
 When the triggered state is activated, the entity contains attributes (if available in the webhook):
 
@@ -44,6 +44,11 @@ trigger:
   group_name: Motion Sensors
   group_id: 3
 ```
+
+Alert type supported :
+- `1130` : INTRUSION
+- `1139` : INTRUSION-CONFIRMED
+- `1141` : PREALARM-CONFIRMED
 
 ## Anomalies - Details
 

--- a/docs/integration/index.mdx
+++ b/docs/integration/index.mdx
@@ -18,16 +18,6 @@ Once HACS is installed, simple click the button below to start the automated ins
 
 ## Via HACS UI
 
-<!-- `Diagral` is a default repository within HACS.  If you do not wish to use the automatic install, you can search for `Diagral` within the HACS interface -->
-
 <Info>
-  The Diagral integration has not yet been validated by HACS to be part of its default repositories.
-  Therefore, it is necessary to manually add the GitHub repository of the Diagral integration or use the automatic method described above.
+  `Diagral` is a default repository within HACS.  If you do not wish to use the automatic install, you can search for `Diagral` within the HACS interface
 </Info>
-
-<Card title="Integration Repository" icon="cog">
-  [Manually add this repository](https://www.hacs.xyz/docs/faq/custom_repositories/) to HACS if you prefer not to use the automated installation below:
-    ```text
-    https://github.com/mguyard/hass-diagral
-    ````
-</Card>


### PR DESCRIPTION
This pull request introduces several updates to the `Diagral` integration, including new features, bug fixes, and documentation improvements. The most notable changes include adding support for an additional alarm code, updating the version to `1.3.0-beta.2`, and revising HACS integration instructions.

### Features and Functionality Updates:
* **Alarm Code Addition:** Added support for the `1141` alarm code (`PREALARM-CONFIRMED`) to the `ALARM_INTRUSION_CODES` set in `alarm_control_panel.py`. This enhances the handling of alert events.

### Versioning Updates:
* **Manifest Update:** Updated the version in `manifest.json` to `1.3.0-beta.2`, reflecting the new release.

### Documentation Improvements:
* **HACS Integration Instructions:** Revised the documentation to reflect that `Diagral` is now a default repository within HACS, removing outdated manual installation instructions.
* **Alarm Code Documentation:** Added descriptions for supported alert types (`1130`, `1139`, `1141`) in `docs/integration/entities.mdx` for better clarity.

### Miscellaneous Updates:
* **Diagnostics Module:** Corrected the module description in `diagnostics.py` to reference `Diagral` instead of `Netatmo`.