### PR TITLE
chore: 🐛 Fix Hassfest translations violation and update VSCode tooling

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,6 @@
       "esbenp.prettier-vscode",
       "ms-python.python",
       "GitHub.vscode-pull-request-github",
-      "GitHub.copilot"
+      "github.copilot-chat"
     ]
   }

--- a/custom_components/diagral/config_flow.py
+++ b/custom_components/diagral/config_flow.py
@@ -176,6 +176,10 @@ class DiagralConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=STEP_SERIALID,
             errors=errors or {},
+            description_placeholders={
+                "setup_guide_url": "https://docs.page/mguyard/hass-diagral/integration/setup#how-to-find-your-system-serial-id",
+                "serial_id_image_url": "https://raw.githubusercontent.com/mguyard/pydiagral/main/docs/how-to-find-diagral-serial.png",
+            },
             last_step=False,
         )
 

--- a/custom_components/diagral/config_flow.py
+++ b/custom_components/diagral/config_flow.py
@@ -352,6 +352,7 @@ class DiagralConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="options",
             data_schema=STEP_OPTIONS,
             errors=errors or {},
+            description_placeholders={"options_url": "https://docs.page/mguyard/hass-diagral/integration/setup#options"},
             last_step=True,
         )
 
@@ -531,6 +532,7 @@ class DiagralOptionsFlow(config_entries.OptionsFlow):
             step_id="init",
             data_schema=STEP_OPTIONS,
             errors=errors or {},
+            description_placeholders={"options_url": "https://docs.page/mguyard/hass-diagral/integration/setup#options"},
             last_step=True,
         )
 

--- a/custom_components/diagral/translations/en.json
+++ b/custom_components/diagral/translations/en.json
@@ -19,7 +19,7 @@
                 "data": {
                     "serial_id": "Serial ID of DIAG56AAX module"
                 },
-                "description": "To set up your Diagral alarm system, you need a DIAG56AAX module which connects your alarm to the internet for remote control.\n\rTo find your Serial ID, check the label on your module or visit our setup guide: https://docs.page/mguyard/hass-diagral/integration/setup#how-to-find-your-system-serial-id\n\r![SerialID Location](https://raw.githubusercontent.com/mguyard/pydiagral/main/docs/how-to-find-diagral-serial.png)",
+                "description": "To set up your Diagral alarm system, you need a DIAG56AAX module which connects your alarm to the internet for remote control.\n\rTo find your Serial ID, check the label on your module or visit our setup guide: [{setup_guide_url}]({setup_guide_url})\n\r![SerialID Location]({serial_id_image_url})",
                 "title": "Diagral"
             },
             "account": {

--- a/custom_components/diagral/translations/en.json
+++ b/custom_components/diagral/translations/en.json
@@ -43,7 +43,7 @@
             },
             "options": {
               "title": "Options",
-              "description": "_More details about these options are available [here](https://docs.page/mguyard/hass-diagral/integration/setup#options)_",
+              "description": "_More details about these options are available [here]({options_url})_",
               "sections": {
                     "alarmpanel_options": {
                         "name": "Alarm Panel Options",
@@ -97,7 +97,7 @@
         "step": {
             "init": {
                 "title": "Options",
-                "description": "_More details about these options are available [here](https://docs.page/mguyard/hass-diagral/integration/setup#options)_",
+                "description": "_More details about these options are available [here]({options_url})_",
                 "sections": {
                     "alarmpanel_options": {
                         "name": "Alarm Panel Options",

--- a/custom_components/diagral/translations/fr.json
+++ b/custom_components/diagral/translations/fr.json
@@ -17,7 +17,7 @@
         "step": {
             "user": {
                 "title": "Diagral",
-                "description": "Pour configurer votre système d'alarme Diagral, vous avez besoin d'un module DIAG56AAX qui connecte votre alarme à Internet pour le contrôle à distance.\n\rPour trouver votre ID de série, vérifiez l'étiquette sur votre module ou consultez notre guide de configuration : https://docs.page/mguyard/hass-diagral/integration/setup#how-to-find-your-system-serial-id\n\r![Emplacement SerialID](https://raw.githubusercontent.com/mguyard/pydiagral/main/docs/how-to-find-diagral-serial.png)",
+                "description": "Pour configurer votre système d'alarme Diagral, vous avez besoin d'un module DIAG56AAX qui connecte votre alarme à Internet pour le contrôle à distance.\n\rPour trouver votre ID de série, vérifiez l'étiquette sur votre module ou consultez notre guide de configuration : [{setup_guide_url}]({setup_guide_url})\n\r![Emplacement SerialID]({serial_id_image_url})",
                 "data": {
                     "serial_id": "Numéro de série du module DIAG56AAX"
                 }

--- a/custom_components/diagral/translations/fr.json
+++ b/custom_components/diagral/translations/fr.json
@@ -42,7 +42,7 @@
             },
             "options": {
                 "title": "Options",
-                "description": "_Plus de détails sur ces options sont disponibles [ici](https://docs.page/mguyard/hass-diagral/integration/setup#options)_",
+                "description": "_Plus de détails sur ces options sont disponibles [ici]({options_url})_",
                 "sections": {
                     "alarmpanel_options": {
                         "name": "Options du panneau d'alarme",
@@ -96,7 +96,7 @@
         "step": {
             "init": {
                 "title": "Options",
-                "description": "_Plus de détails sur ces options sont disponibles [ici](https://docs.page/mguyard/hass-diagral/integration/setup#options)_",
+                "description": "_Plus de détails sur ces options sont disponibles [ici]({options_url})_",
                 "sections": {
                     "alarmpanel_options": {
                         "name": "Options du panneau d'alarme",


### PR DESCRIPTION
## Summary

This PR merges the `dev` branch into `beta` and includes 3 commits.

---

## Commits

### `fix(translations): 🐛 Replace raw URLs in user step description` — [22653f6](https://github.com/mguyard/hass-diagral/commit/22653f6)

Fixes a remaining Hassfest validation failure (`[TRANSLATIONS]`) on `config.step.user.description` which contained two hard-coded URLs.

**Changes:**
- `custom_components/diagral/translations/en.json` — replaced hard-coded URLs in `config.step.user.description` with `{setup_guide_url}` and `{serial_id_image_url}` placeholders
- `custom_components/diagral/translations/fr.json` — same replacement for French locale
- `custom_components/diagral/config_flow.py` — added `description_placeholders` with `setup_guide_url` and `serial_id_image_url` to `async_show_form` in `async_step_user()`

Closes #61

---

### `fix(translations): 🐛 Replace raw URLs with description_placeholders` — [3ed070b](https://github.com/mguyard/hass-diagral/commit/3ed070b790f2c7e0a88f84cb52f50c83d97d5f96)

Fixes a Hassfest validation failure (`[TRANSLATIONS]`) caused by raw URLs hard-coded inside translation strings for the options step.

**Changes:**
- `custom_components/diagral/translations/en.json` — replaced hard-coded URL in `config.step.options.description` and `options.step.init.description` with the `{options_url}` placeholder
- `custom_components/diagral/translations/fr.json` — same replacement for French locale
- `custom_components/diagral/config_flow.py` — added `description_placeholders={"options_url": ...}` to `async_show_form` in `DiagralConfigFlow.async_step_options()` and `DiagralOptionsFlow.async_step_init()`

Closes #61

---

### `chore(vscode): 🔧 Update GitHub Copilot extension reference` — [b6ae777](https://github.com/mguyard/hass-diagral/commit/b6ae777b7b8ddb5052e961a027721bcec06d1273)

Internal tooling change only, no impact on the integration.

**Changes:**
- `.vscode/extensions.json` — updated extension reference from `GitHub.copilot` to `github.copilot-chat`

---

## Validation

- [x] Hassfest translation validation passes (no raw URLs in translation strings)
- [x] HACS validation unaffected