### PR TITLE
fix: 🐛 Fix Hassfest validation errors and update tooling (v1.3.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -121,3 +121,10 @@ body:
           required: true
         - label: This issue is not a duplicate issue of currently [previous issues](https://github.com/mguyard/hass-diagral/issues?q=label%3Abug)..
           required: true
+
+# copilot-note:
+# 🚦 For GitHub Copilot Coding Agent:
+# 1. You MUST read and strictly follow all project-specific instructions in `.github/copilot-instructions.md` before starting any work.
+# 2. When opening a pull request, you MUST use 'dev' as the base branch — no exceptions.
+# 3. Your first response MUST always explicitly confirm you have read and will comply with `.github/copilot-instructions.md`.
+# 4. If you do not comply with these rules, your PR or contribution may be rejected.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -62,3 +62,10 @@ body:
           required: true
         - label: This issue is not a duplicate feature request of [previous feature requests](https://github.com/mguyard/hass-diagral/issues?q=label%3Afeature).
           required: true
+
+# copilot-note:
+# 🚦 For GitHub Copilot Coding Agent:
+# 1. You MUST read and strictly follow all project-specific instructions in `.github/copilot-instructions.md` before starting any work.
+# 2. When opening a pull request, you MUST use 'dev' as the base branch — no exceptions.
+# 3. Your first response MUST always explicitly confirm you have read and will comply with `.github/copilot-instructions.md`.
+# 4. If you do not comply with these rules, your PR or contribution may be rejected.

--- a/.github/copilot-commit-message-instructions.md
+++ b/.github/copilot-commit-message-instructions.md
@@ -10,7 +10,13 @@ Guidelines:
 
 1. **Type and Scope**: Choose an appropriate type (e.g., `feat`, `fix`) and optional scope to describe the affected module or feature.
 
-2. **Gitmoji**: Include a relevant `gitmoji` that best represents the nature of the change.
+2. **Gitmoji**: Use the following gitmoji for each commit type to ensure consistency:
+   - `feat`: ✨ (sparkles) — For new features
+   - `fix`: 🐛 (bug) — For bug fixes
+   - `docs`: 📝 (memo) — For documentation changes (including anything in `docs/` or `docs.json`)
+   - `refactor`: ♻️ (recycle) — For code refactoring that does not add features or fix bugs
+   - `test`: ✅ (white check mark) — For adding or updating tests
+   - `chore`: 🔧 (wrench) — For maintenance, build, or tooling changes
 
 3. **Description**: Write a concise, informative description in the header; use backticks if referencing code or specific terms.
 
@@ -18,8 +24,43 @@ Guidelines:
    - Use bullet points (`*`) for clarity.
    - Clearly describe the motivation, context, or technical details behind the change, if applicable.
 
+
+**Examples:**
+
+```
+feat(alarm_control_panel): ✨ Add support for partial arming mode
+
+* Implements `partial` arming for Diagral alarm.
+* Updates UI to reflect new mode.
+```
+
+```
+docs(readme): 📝 Update README with troubleshooting section
+
+* Adds common issues and solutions for Diagral integration.
+```
+
+```
+fix(sensor): 🐛 Fix humidity sensor value conversion
+```
+
+```
+refactor(coordinator): ♻️ Refactor update logic for better reliability
+```
+
+```
+test(alarm_control_panel): ✅ Add tests for alarm state transitions
+```
+
+```
+chore(deps): 🔧 Bump minimum Home Assistant version to 2024.6.0
+```
+
+**Rules:**
+
+- Limit the first line to 72 characters or less.
+- Use backticks for code/entity references in the description.
+- Write the body in bullet points for clarity if needed.
+- Always write commit messages in English.
+
 Commit messages should be clear, informative, and professional, aiding readability and project tracking.
-
-Limit the first line to 72 characters or less.
-
-Always write in English to maintain consistency and clarity across the project.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,139 @@
+# GitHub Copilot Custom Instructions for `hass-diagral`
+
+## Project Context
+
+- **Project Type:**  
+  This repository is a **custom integration for [Home Assistant](https://www.home-assistant.io/)**, written in Python.
+- **Purpose:**  
+  The integration connects Home Assistant to the Diagral alarm system, exposing alarm states, sensors, and diagnostics, and providing Home Assistant entities, events, and configuration flows.
+- **Structure:**  
+  - All integration code is in `custom_components/diagral/`.
+  - Documentation is in the `docs/` directory and `docs.json`.
+  - The integration uses Home Assistant's config flow, entity platforms (sensor, alarm_control_panel, etc.), and DataUpdateCoordinator pattern.
+  - The codebase follows Home Assistant's best practices for custom components.
+- **Language:**  
+  - All code, comments, and docstrings must be in **English** (even though the maintainer is French).
+- **Documentation:**  
+  - All files in `docs/` and `docs.json` are documentation and must use the `docs` commit type.
+  - Documentation is in Markdown or MDX, and must be clear and concise.
+- **Testing:**  
+  - Use `pytest` conventions for tests (if/when present).
+  - Place tests in a `tests/` directory.
+  - **Always suggest adding or updating tests when new features or bug fixes are implemented.**
+- **Linting/Formatting:**  
+  - Use `flake8` as the linter, with a maximum line length of 150 characters (see `.vscode/settings.json`).
+  - You may also use `black` for formatting if desired, but `flake8` is required for linting.
+
+## External Context and Libraries
+
+- You may use context7 for code generation and suggestions.
+- You are allowed to use libraries and APIs from:
+  - `/home-assistant/core`
+  - [developers.home-assistant.io](https://developers.home-assistant.io)
+- Use these resources to ensure compatibility and best practices with Home Assistant integrations.
+
+## Pull Request Best Practices
+
+- **Title:**
+  - The PR title MUST follow the same format as the commit message guidelines (see below):
+    `<type>[optional scope]: <gitmoji> <description>`
+  - The title should summarize the main purpose of the PR.
+
+- **Description:**
+  - The PR description MUST provide a clear summary of all changes included in the PR.
+  - List and briefly explain each commit included in the PR.
+  - For each commit, include a direct link to the commit (e.g., `https://github.com/mguyard/hass-diagral/commit/<sha>`).
+  - If the PR addresses or closes issues, reference them using GitHub keywords (e.g., `Closes #123`).
+  - Use bullet points for clarity if needed.
+
+- **Branch:**
+  - All PRs MUST use `dev` as the base branch.
+
+- **General:**
+  - Ensure your PR is focused and does not mix unrelated changes.
+  - Follow all other project and commit message guidelines described above.
+
+
+## Commit Message Guidelines
+
+- **Format:**  
+  ```
+  <type>[optional scope]: <gitmoji> <description>
+
+  [optional body]
+  ```
+- **Types and Gitmoji:**  
+  Use the following gitmoji for each commit type to ensure consistency:
+  - `feat`: ✨ (sparkles) — For new features
+  - `fix`: 🐛 (bug) — For bug fixes
+  - `docs`: 📝 (memo) — For documentation changes (including anything in `docs/` or `docs.json`)
+  - `refactor`: ♻️ (recycle) — For code refactoring that does not add features or fix bugs
+  - `test`: ✅ (white check mark) — For adding or updating tests
+  - `chore`: 🔧 (wrench) — For maintenance, build, or tooling changes
+
+- **Examples:**
+  ```
+  feat(alarm_control_panel): ✨ Add support for partial arming mode
+
+  * Implements `partial` arming for Diagral alarm.
+  * Updates UI to reflect new mode.
+  ```
+
+  ```
+  docs(readme): 📝 Update README with troubleshooting section
+
+  * Adds common issues and solutions for Diagral integration.
+  ```
+
+  ```
+  fix(sensor): 🐛 Fix humidity sensor value conversion
+  ```
+
+  ```
+  refactor(coordinator): ♻️ Refactor update logic for better reliability
+  ```
+
+  ```
+  test(alarm_control_panel): ✅ Add tests for alarm state transitions
+  ```
+
+  ```
+  chore(deps): 🔧 Bump minimum Home Assistant version to 2024.6.0
+  ```
+
+- **Rules:**
+  - Limit the first line to 72 characters or less.
+  - Use backticks for code/entity references in the description.
+  - Write the body in bullet points for clarity if needed.
+  - Always write commit messages in English.
+
+## Python-Specific Best Practices
+
+- Use virtual environments for development.
+- Use `async`/`await` for I/O-bound operations.
+- Handle exceptions gracefully and log errors.
+- Use `logging` instead of `print` for output.
+- Prefer list comprehensions and generator expressions for concise code.
+- Avoid global variables.
+- Use constants for configuration values.
+
+## Home Assistant Integration
+
+- Follow [Home Assistant custom component guidelines](https://developers.home-assistant.io/docs/creating_component_index/).
+- Entities should have unique IDs and meaningful names.
+- Use translations for entity names and options.
+- Ensure all entities are documented in `docs/integration/entities.mdx`.
+
+## For Copilot Coding Agent
+
+- When asked to create or modify files, always use English for code, comments, and docstrings.
+- When generating documentation, use Markdown or MDX and English.
+- When generating commit messages, follow the Conventional Commits and gitmoji rules above.
+- When working with Home Assistant, prefer async APIs and follow the entity/component patterns in the codebase.
+- All configuration, code, and documentation must be consistent with the existing project structure and standards.
+- **Always suggest adding or updating tests for new features or bug fixes.**
+- **Enforce flake8 linting with a max line length of 150 characters.**
+
+---
+
+These instructions are designed to help GitHub Copilot and Copilot Coding Agent generate code, documentation, and commit messages that are consistent with the project's standards and best practices.

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,44 @@
+---
+name: CodeQL
+
+on:
+  schedule:
+    # Run CodeQL analysis every Saturday at 1:00 AM UTC (3:00 AM Paris time)
+    - cron: '0 1 * * 6'
+  workflow_dispatch:
+    # Allow manual trigger
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['python']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -36,9 +36,9 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/devsec.yaml
+++ b/.github/workflows/devsec.yaml
@@ -10,7 +10,7 @@ jobs:
     SecurityScan:
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - name: SAST
           run: |
             env | grep -E "GITHUB_ACTIONS|GITHUB_RUN_NUMBER|GITHUB_REF_NAME|GITHUB_SHA" > /tmp/env

--- a/.github/workflows/devsec.yaml
+++ b/.github/workflows/devsec.yaml
@@ -1,0 +1,17 @@
+name: FortiDevSec Scanner CI
+on:
+    push:
+        branches: 
+          - dev
+    pull_request:
+        branches: 
+          - dev
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v4
+        - name: SAST
+          run: |
+            env | grep -E "GITHUB_ACTIONS|GITHUB_RUN_NUMBER|GITHUB_REF_NAME|GITHUB_SHA" > /tmp/env
+            docker run --pull always --rm --env-file /tmp/env --mount type=bind,source=$PWD,target=/scan registry.fortidevsec.forticloud.com/fdevsec_sast:latest

--- a/.github/workflows/devsec.yaml
+++ b/.github/workflows/devsec.yaml
@@ -7,7 +7,7 @@ on:
         branches: 
           - dev
 jobs:
-    build:
+    SecurityScan:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/devsec.yaml
+++ b/.github/workflows/devsec.yaml
@@ -10,7 +10,7 @@ jobs:
     SecurityScan:
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v5
+        - uses: actions/checkout@v6
         - name: SAST
           run: |
             env | grep -E "GITHUB_ACTIONS|GITHUB_RUN_NUMBER|GITHUB_REF_NAME|GITHUB_SHA" > /tmp/env

--- a/.github/workflows/home-assistant.yaml
+++ b/.github/workflows/home-assistant.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Hassfest Validation
     runs-on: "ubuntu-latest"
     steps:
-        - uses: "actions/checkout@v4"
+        - uses: "actions/checkout@v5"
         - uses: "home-assistant/actions/hassfest@master"
 
   validate-hacs:

--- a/.github/workflows/home-assistant.yaml
+++ b/.github/workflows/home-assistant.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Hassfest Validation
     runs-on: "ubuntu-latest"
     steps:
-        - uses: "actions/checkout@v5"
+        - uses: "actions/checkout@v6"
         - uses: "home-assistant/actions/hassfest@master"
 
   validate-hacs:

--- a/.github/workflows/labelers.yml
+++ b/.github/workflows/labelers.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run Labeler
         uses: crazy-max/ghaction-github-labeler@v5.3.0

--- a/.github/workflows/labelers.yml
+++ b/.github/workflows/labelers.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Run Labeler
         uses: crazy-max/ghaction-github-labeler@v5.3.0

--- a/.github/workflows/lock-stale.yml
+++ b/.github/workflows/lock-stale.yml
@@ -27,7 +27,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           any-of-issue-labels: "waiting-for-response"
           days-before-issue-stale: 30

--- a/.github/workflows/lock-stale.yml
+++ b/.github/workflows/lock-stale.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository_owner == 'mguyard'
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5.0.1
+      - uses: dessant/lock-threads@v6.0.0
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '30'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       name: Semver #your environment name
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Install semantic-release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       name: Semver #your environment name
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Install semantic-release

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,6 @@
       "esbenp.prettier-vscode",
       "ms-python.python",
       "GitHub.vscode-pull-request-github",
-      "GitHub.copilot"
+      "github.copilot-chat"
     ]
   }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,12 @@
+{
+  "servers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.3.1-beta.1](https://github.com/mguyard/hass-diagral/compare/v1.3.0...v1.3.1-beta.1) (2026-01-05)
+
+
+### Bug Fixes
+
+* **fdevsec.yaml:** 🔧 Update `risk_rating` to 9 for pipeline failure ([8960aa4](https://github.com/mguyard/hass-diagral/commit/8960aa4c093000d6d559ad94752e732ec506fe1c))
+
 # [1.3.0](https://github.com/mguyard/hass-diagral/compare/v1.2.0...v1.3.0) (2025-06-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.3.1-beta.2](https://github.com/mguyard/hass-diagral/compare/v1.3.1-beta.1...v1.3.1-beta.2) (2026-02-22)
+
+
+### Bug Fixes
+
+* **translations:** 🐛 Replace raw URLs in user step description ([22653f6](https://github.com/mguyard/hass-diagral/commit/22653f68b9f480c1a527baa6145e03dbeb81de9b)), closes [#61](https://github.com/mguyard/hass-diagral/issues/61)
+* **translations:** 🐛 Replace raw URLs with description_placeholders ([3ed070b](https://github.com/mguyard/hass-diagral/commit/3ed070b790f2c7e0a88f84cb52f50c83d97d5f96)), closes [#61](https://github.com/mguyard/hass-diagral/issues/61)
+
 ## [1.3.1-beta.1](https://github.com/mguyard/hass-diagral/compare/v1.3.0...v1.3.1-beta.1) (2026-01-05)
 
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 	<img src="https://img.shields.io/github/languages/count/mguyard/hass-diagral?style=default&color=0080ff" alt="repo-language-count">
 <p>
 <p align="center">
-    <img src="https://img.shields.io/github/v/release/mguyard/hass-diagral?label=Stable" alt="Last Stable Release">
+    <img src="https://img.shields.io/github/v/release/mguyard/hass-diagral?display_date=published_at&label=Stable" alt="Last Stable Release">
     <img src="https://img.shields.io/github/release-date/mguyard/hass-diagral?label=Stable" alt="Last Release Date Stable">
-    <img src="https://img.shields.io/github/v/release/mguyard/hass-diagral?label=Beta&include_prereleases" alt="Last Beta Release">
-    <img src="https://img.shields.io/github/release-date/mguyard/hass-diagral?label=Beta" alt="Last Release Date Beta">
+    <img src="https://img.shields.io/github/v/release/mguyard/hass-diagral?include_prereleases&filter=*-beta.*&display_name=release&label=Beta" alt="Last Beta Release">
+    <img src="https://img.shields.io/github/release-date-pre/mguyard/hass-diagral?display_date=published_at&label=Beta" alt="Last Release Date Beta">
     <img src="https://img.shields.io/github/issues-search/mguyard/hass-diagral?query=label%3Abug%20is%3Aopened&label=Open%20Bugs" alt="Open Bugs">
     <img src="https://img.shields.io/github/issues-pr/mguyard/hass-diagral" alt="Open PRs">
 <p>

--- a/custom_components/diagral/config_flow.py
+++ b/custom_components/diagral/config_flow.py
@@ -176,6 +176,10 @@ class DiagralConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=STEP_SERIALID,
             errors=errors or {},
+            description_placeholders={
+                "setup_guide_url": "https://docs.page/mguyard/hass-diagral/integration/setup#how-to-find-your-system-serial-id",
+                "serial_id_image_url": "https://raw.githubusercontent.com/mguyard/pydiagral/main/docs/how-to-find-diagral-serial.png",
+            },
             last_step=False,
         )
 

--- a/custom_components/diagral/config_flow.py
+++ b/custom_components/diagral/config_flow.py
@@ -352,6 +352,7 @@ class DiagralConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="options",
             data_schema=STEP_OPTIONS,
             errors=errors or {},
+            description_placeholders={"options_url": "https://docs.page/mguyard/hass-diagral/integration/setup#options"},
             last_step=True,
         )
 
@@ -531,6 +532,7 @@ class DiagralOptionsFlow(config_entries.OptionsFlow):
             step_id="init",
             data_schema=STEP_OPTIONS,
             errors=errors or {},
+            description_placeholders={"options_url": "https://docs.page/mguyard/hass-diagral/integration/setup#options"},
             last_step=True,
         )
 

--- a/custom_components/diagral/manifest.json
+++ b/custom_components/diagral/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/mguyard/hass-diagral/issues",
   "quality_scale": "bronze",
   "requirements": ["pydiagral==1.6.0"],
-  "version": "1.3.1-beta.1"
+  "version": "1.3.1-beta.2"
 }

--- a/custom_components/diagral/manifest.json
+++ b/custom_components/diagral/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/mguyard/hass-diagral/issues",
   "quality_scale": "bronze",
   "requirements": ["pydiagral==1.6.0"],
-  "version": "1.3.0"
+  "version": "1.3.1-beta.1"
 }

--- a/custom_components/diagral/services.yaml
+++ b/custom_components/diagral/services.yaml
@@ -1,7 +1,8 @@
 arm_groups:
   target:
-    device:
+    entity:
       integration: diagral
+      domain: alarm_control_panel
   fields:
     group_ids:
       example: "[3,2] or 3"
@@ -11,8 +12,9 @@ arm_groups:
 
 disarm_groups:
   target:
-    device:
+    entity:
       integration: diagral
+      domain: alarm_control_panel
   fields:
     group_ids:
       example: "[3,2] or 3"
@@ -22,10 +24,12 @@ disarm_groups:
 
 register_webhook:
   target:
-    device:
+    entity:
       integration: diagral
+      domain: alarm_control_panel
 
 unregister_webhook:
   target:
-    device:
+    entity:
       integration: diagral
+      domain: alarm_control_panel

--- a/custom_components/diagral/translations/en.json
+++ b/custom_components/diagral/translations/en.json
@@ -19,7 +19,7 @@
                 "data": {
                     "serial_id": "Serial ID of DIAG56AAX module"
                 },
-                "description": "To set up your Diagral alarm system, you need a DIAG56AAX module which connects your alarm to the internet for remote control.\n\rTo find your Serial ID, check the label on your module or visit our setup guide: https://docs.page/mguyard/hass-diagral/integration/setup#how-to-find-your-system-serial-id\n\r![SerialID Location](https://raw.githubusercontent.com/mguyard/pydiagral/main/docs/how-to-find-diagral-serial.png)",
+                "description": "To set up your Diagral alarm system, you need a DIAG56AAX module which connects your alarm to the internet for remote control.\n\rTo find your Serial ID, check the label on your module or visit our setup guide: [{setup_guide_url}]({setup_guide_url})\n\r![SerialID Location]({serial_id_image_url})",
                 "title": "Diagral"
             },
             "account": {

--- a/custom_components/diagral/translations/en.json
+++ b/custom_components/diagral/translations/en.json
@@ -43,7 +43,7 @@
             },
             "options": {
               "title": "Options",
-              "description": "_More details about these options are available [here](https://docs.page/mguyard/hass-diagral/integration/setup#options)_",
+              "description": "_More details about these options are available [here]({options_url})_",
               "sections": {
                     "alarmpanel_options": {
                         "name": "Alarm Panel Options",
@@ -97,7 +97,7 @@
         "step": {
             "init": {
                 "title": "Options",
-                "description": "_More details about these options are available [here](https://docs.page/mguyard/hass-diagral/integration/setup#options)_",
+                "description": "_More details about these options are available [here]({options_url})_",
                 "sections": {
                     "alarmpanel_options": {
                         "name": "Alarm Panel Options",

--- a/custom_components/diagral/translations/fr.json
+++ b/custom_components/diagral/translations/fr.json
@@ -17,7 +17,7 @@
         "step": {
             "user": {
                 "title": "Diagral",
-                "description": "Pour configurer votre système d'alarme Diagral, vous avez besoin d'un module DIAG56AAX qui connecte votre alarme à Internet pour le contrôle à distance.\n\rPour trouver votre ID de série, vérifiez l'étiquette sur votre module ou consultez notre guide de configuration : https://docs.page/mguyard/hass-diagral/integration/setup#how-to-find-your-system-serial-id\n\r![Emplacement SerialID](https://raw.githubusercontent.com/mguyard/pydiagral/main/docs/how-to-find-diagral-serial.png)",
+                "description": "Pour configurer votre système d'alarme Diagral, vous avez besoin d'un module DIAG56AAX qui connecte votre alarme à Internet pour le contrôle à distance.\n\rPour trouver votre ID de série, vérifiez l'étiquette sur votre module ou consultez notre guide de configuration : [{setup_guide_url}]({setup_guide_url})\n\r![Emplacement SerialID]({serial_id_image_url})",
                 "data": {
                     "serial_id": "Numéro de série du module DIAG56AAX"
                 }

--- a/custom_components/diagral/translations/fr.json
+++ b/custom_components/diagral/translations/fr.json
@@ -42,7 +42,7 @@
             },
             "options": {
                 "title": "Options",
-                "description": "_Plus de détails sur ces options sont disponibles [ici](https://docs.page/mguyard/hass-diagral/integration/setup#options)_",
+                "description": "_Plus de détails sur ces options sont disponibles [ici]({options_url})_",
                 "sections": {
                     "alarmpanel_options": {
                         "name": "Options du panneau d'alarme",
@@ -96,7 +96,7 @@
         "step": {
             "init": {
                 "title": "Options",
-                "description": "_Plus de détails sur ces options sont disponibles [ici](https://docs.page/mguyard/hass-diagral/integration/setup#options)_",
+                "description": "_Plus de détails sur ces options sont disponibles [ici]({options_url})_",
                 "sections": {
                     "alarmpanel_options": {
                         "name": "Options du panneau d'alarme",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -11,7 +11,7 @@ nextTitle: Installation
     <Image src="https://img.shields.io/github/languages/count/mguyard/hass-diagral?style=default&color=0080ff" alt="repo-language-count" />
 </Badges>
 <Badges>
-    <Image src="https://img.shields.io/github/v/release/mguyard/hass-diagral?label=Stable" alt="Last Stable Release" />
+    <Image src="https://img.shields.io/github/v/release/mguyard/hass-diagral?display_date=published_at&label=Stable" alt="Last Stable Release" />
     <Image src="https://img.shields.io/github/release-date/mguyard/hass-diagral?label=Stable" alt="Last Release Date Stable" />
     <Image src="https://img.shields.io/github/v/release/mguyard/hass-diagral?include_prereleases&filter=*-beta.*&display_name=release&label=Beta" alt="Last Beta Release" />
     <Image src="https://img.shields.io/github/release-date-pre/mguyard/hass-diagral?display_date=published_at&label=Beta" alt="Last Release Date Beta" />

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -13,8 +13,8 @@ nextTitle: Installation
 <Badges>
     <Image src="https://img.shields.io/github/v/release/mguyard/hass-diagral?label=Stable" alt="Last Stable Release" />
     <Image src="https://img.shields.io/github/release-date/mguyard/hass-diagral?label=Stable" alt="Last Release Date Stable" />
-    <Image src="https://img.shields.io/github/v/release/mguyard/hass-diagral?label=Beta&include_prereleases" alt="Last Beta Release" />
-    <Image src="https://img.shields.io/github/release-date-pre/mguyard/hass-diagral?label=Beta" alt="Last Release Date Beta" />
+    <Image src="https://img.shields.io/github/v/release/mguyard/hass-diagral?include_prereleases&filter=*-beta.*&display_name=release&label=Beta" alt="Last Beta Release" />
+    <Image src="https://img.shields.io/github/release-date-pre/mguyard/hass-diagral?display_date=published_at&label=Beta" alt="Last Release Date Beta" />
     <Image src="https://img.shields.io/github/issues-search/mguyard/hass-diagral?query=label%3Abug%20is%3Aopened&label=Open%20Bugs" alt="Open Bugs" />
     <Image src="https://img.shields.io/github/issues-pr/mguyard/hass-diagral" alt="Open PRs" />
 </Badges>

--- a/fdevsec.yaml
+++ b/fdevsec.yaml
@@ -1,0 +1,40 @@
+id:
+  org: 6a8011f2-638c-4aaf-9856-759993b02004
+  app: b1089c0a-aaf5-4daa-a49a-5e8d69767d12
+
+# If below settings are not configured, scans will be performed for all supported scanners.
+#scanners:
+#  - sast
+#  - sca
+#  - secret
+#  - iac
+#  - container
+#  - dast
+
+# Configures languages for sast scanner. If not configured, scans will be performed on all supported languages
+languages:
+#  - javascript
+  - python
+
+# Configures target url where dynamic scan should be performed.
+#dast:
+#  url: https://your.url.com
+#  full_scan: true #true|false
+
+# Language scanners run sequentially by default. Can be configured to run in parallel.
+#resource:
+#  serial_scan: true #true|false
+
+# Configures files or directories that should be excluded from the scan
+#exclude_path:
+#  - example_dir
+#  - example_file.extension
+
+# CI/CD pipeline fails when risk rating(range 0-9) exceeds the configured value.
+fail_pipeline:
+  risk_rating: 1
+
+# Only for FortiDevSec OnPrem users. Cloud users should keep it commented
+#on_prem:
+#  sec_ops_server: {your_onprem_fortidevsec_server_url}
+

--- a/fdevsec.yaml
+++ b/fdevsec.yaml
@@ -32,7 +32,7 @@ languages:
 
 # CI/CD pipeline fails when risk rating(range 0-9) exceeds the configured value.
 fail_pipeline:
-  risk_rating: 1
+  risk_rating: 9
 
 # Only for FortiDevSec OnPrem users. Cloud users should keep it commented
 #on_prem:


### PR DESCRIPTION
## Summary

Release **v1.3.1** — merges `beta` into `main`.

This release contains two bug fixes required to pass Hassfest validation, a services.yaml refactor, dependency bumps, and several tooling/CI improvements.

---

## Bug Fixes

### `fix(translations): 🐛 Replace raw URLs in user step description` — [22653f6](https://github.com/mguyard/hass-diagral/commit/22653f6)

- Removed hard-coded URLs from `config.step.user.description` in `en.json` and `fr.json`
- Added `description_placeholders` (`setup_guide_url`, `serial_id_image_url`) to `async_step_user()` in `config_flow.py`

### `fix(translations): 🐛 Replace raw URLs with description_placeholders` — [3ed070b](https://github.com/mguyard/hass-diagral/commit/3ed070b)

- Removed hard-coded URLs from `config.step.options.description` and `options.step.init.description` in `en.json` and `fr.json`
- Added `description_placeholders` (`options_url`) to `async_step_options()` and `async_step_init()` in `config_flow.py`

Closes #61

### `fix(fdevsec.yaml): 🔧 Update risk_rating to 9 for pipeline failure` — [8960aa4](https://github.com/mguyard/hass-diagral/commit/8960aa4)

- Updated `risk_rating` threshold in FortiDevSec config to prevent false pipeline failures

---

## Refactoring

### `refactor(alarm_control_panel): ♻️ Change device to entity in services.yaml` — [f51d746](https://github.com/mguyard/hass-diagral/commit/f51d746)

- Fixed Hassfest `[SERVICES]` validation error: replaced unsupported `device` filter on target with an `entity` selector in `services.yaml`

---

## CI / Tooling

### `chore(ci): 🚀 Add FortiDevSec Scanner CI workflow` — [46853f3](https://github.com/mguyard/hass-diagral/commit/46853f3)
### `chore(ci): 🔒 Rename job from build to SecurityScan` — [61e454d](https://github.com/mguyard/hass-diagral/commit/61e454d)
### `chore(workflow): ✨ Add CodeQL analysis workflow` — [4e13ee1](https://github.com/mguyard/hass-diagral/commit/4e13ee1)
### `chore(copilot-instructions): 📝 Add custom instructions for GitHub Copilot` — [4447ddf](https://github.com/mguyard/hass-diagral/commit/4447ddf)
### `chore(issue_template): 🔧 Add Copilot instructions to issue templates` — [5b547f6](https://github.com/mguyard/hass-diagral/commit/5b547f6)
### `chore(mcp.json): ✨ Add MCP server configuration` — [888d3ba](https://github.com/mguyard/hass-diagral/commit/888d3ba)
### `chore(vscode): 🔧 Update GitHub Copilot extension reference` — [b6ae777](https://github.com/mguyard/hass-diagral/commit/b6ae777)

---

## Dependencies

### `chore(deps): bump dessant/lock-threads from 5.0.1 to 6.0.0` — [9858a45](https://github.com/mguyard/hass-diagral/commit/9858a45)
### `chore(deps): bump actions/checkout from 5 to 6` — [4a050c0](https://github.com/mguyard/hass-diagral/commit/4a050c0)
### `chore(deps): bump github/codeql-action from 3 to 4` — [e800d37](https://github.com/mguyard/hass-diagral/commit/e800d37)
### `chore(deps): bump actions/stale from 9 to 10` — [9713766](https://github.com/mguyard/hass-diagral/commit/9713766)
### `chore(deps): bump actions/checkout from 4 to 5` — [ce80813](https://github.com/mguyard/hass-diagral/commit/ce80813)

---

## Documentation

### `docs: 📝 Update badge links for stable and beta releases` — [3829c78](https://github.com/mguyard/hass-diagral/commit/3829c78) / [9ef41f7](https://github.com/mguyard/hass-diagral/commit/9ef41f7)

---

## Validation

- [x] Hassfest translation validation passes (no raw URLs in translation strings)
- [x] Hassfest services validation passes (`entity` selector instead of `device` filter)
- [x] HACS validation passes